### PR TITLE
Add unit tests for DenseVector

### DIFF
--- a/sprs/src/dense_vector.rs
+++ b/sprs/src/dense_vector.rs
@@ -324,3 +324,111 @@ mod seal {
     {
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use ndarray::{arr1, Array1};
+
+    // Tests on primitive arrays
+    #[test]
+    fn test_dim_of_empty_array() {
+        let vec: [i32; 0] = [];
+        assert_eq!(vec.dim(), 0);
+    }
+
+    #[test]
+    fn test_dim_of_non_empty_array() {
+        let vec = [10, 20];
+        assert_eq!(vec.dim(), 2);
+    }
+
+    #[test]
+    fn test_indexing_array() {
+        let vec: [i32; 3] = [10, 20, 30];
+        assert_eq!(*(vec.index(0)), 10);
+        assert_eq!(*(vec.index(1)), 20);
+        assert_eq!(*(vec.index(2)), 30);
+    }
+
+    #[test]
+    fn test_zeros_on_array() {
+        const DIM: usize = 5;
+        let vec = <[i32] as DenseVector>::zeros(DIM);
+        for i in 0..DIM {
+            assert_eq!(vec[i], 0);
+        }
+    }
+
+    // Tests on vectors
+    #[test]
+    fn test_dim_of_empty_vector() {
+        let vec: Vec<i32> = vec![];
+        assert_eq!(vec.dim(), 0);
+    }
+
+    #[test]
+    fn test_dim_of_non_empty_vector() {
+        let vec = vec![10, 20];
+        assert_eq!(vec.dim(), 2);
+    }
+
+    #[test]
+    fn test_dim_of_varying_size_vector() {
+        let mut vec: Vec<i32> = vec![];
+        assert_eq!(vec.dim(), 0);
+        vec.push(10);
+        assert_eq!(vec.dim(), 1);
+        vec.push(20);
+        assert_eq!(vec.dim(), 2);
+        vec.clear();
+        assert_eq!(vec.dim(), 0);
+    }
+
+    #[test]
+    fn test_indexing_vector() {
+        let vec = vec![10, 20, 30];
+        assert_eq!(*(vec.index(0)), 10);
+        assert_eq!(*(vec.index(1)), 20);
+        assert_eq!(*(vec.index(2)), 30);
+    }
+
+    #[test]
+    fn test_zeros_on_vector() {
+        const DIM: usize = 5;
+        let vec = Vec::<i32>::zeros(DIM);
+        for i in 0..DIM {
+            assert_eq!(vec[i], 0);
+        }
+    }
+
+    // Tests on ArrayBase
+    #[test]
+    fn test_dim_of_empty_ndarray() {
+        let array = Array1::<i32>::zeros(0);
+        assert_eq!(array.dim(), 0);
+    }
+
+    #[test]
+    fn test_dim_of_non_empty_ndarray() {
+        let array = Array1::<i32>::zeros(3);
+        assert_eq!(array.dim(), 3);
+    }
+
+    #[test]
+    fn test_indexing_ndarray() {
+        let array = arr1(&[10, 20, 30]);
+        assert_eq!(*(array.index(0)), 10);
+        assert_eq!(*(array.index(1)), 20);
+        assert_eq!(*(array.index(2)), 30);
+    }
+
+    #[test]
+    fn test_zeros_on_ndarray() {
+        const DIM: usize = 5;
+        let array = <Array1<i32> as DenseVector>::zeros(DIM);
+        for i in 0..DIM {
+            assert_eq!(array[i], 0);
+        }
+    }
+}

--- a/sprs/src/sparse/prod.rs
+++ b/sprs/src/sparse/prod.rs
@@ -615,6 +615,10 @@ mod test {
     }
 
     #[test]
+    #[cfg_attr(
+        miri,
+        ignore = "https://github.com/rust-ndarray/ndarray/issues/1178"
+    )]
     fn test_sparse_dot_dense() {
         let sparse = [
             mat1(),
@@ -649,6 +653,10 @@ mod test {
     }
 
     #[test]
+    #[cfg_attr(
+        miri,
+        ignore = "https://github.com/rust-ndarray/ndarray/issues/1178"
+    )]
     fn test_dense_dot_sparse() {
         let sparse = [
             mat1(),


### PR DESCRIPTION
I've added some code to tests the DenseVector trait.

I used [tarpaulin](https://github.com/xd009642/tarpaulin) to evaluate the coverage improvement of the dense_vector.rs file: from 35% to 64%.

The tests are pretty simple. If you agree, I'd like to write some more unit tests to get confident with the library code and after that contributing on the algorithms.

I've a C++ dev background, and I've recently started learning Rust, so feel free to highlight any mistakes a did.