### PR TITLE
Derive Clone for VectorIterator

### DIFF
--- a/sprs/src/sparse/vec.rs
+++ b/sprs/src/sparse/vec.rs
@@ -73,6 +73,7 @@ where
 }
 
 /// An iterator over the non-zero elements of a sparse vector
+#[derive(Clone)]
 pub struct VectorIterator<'a, N: 'a, I: 'a> {
     ind_data: Zip<Iter<'a, I>, Iter<'a, N>>,
 }


### PR DESCRIPTION
This adds deriving of `Clone` for `VectorIterator`. This is relevant e.g. for [`multi_cartesian_product`](https://docs.rs/itertools/latest/itertools/trait.Itertools.html#method.multi_cartesian_product) from `itertools`.