### PR TITLE
update pattern type

### DIFF
--- a/sprs/data/matrix_market/pattern.mm
+++ b/sprs/data/matrix_market/pattern.mm
@@ -1,0 +1,27 @@
+%%MatrixMarket matrix coordinate pattern general
+%===============================================================================
+%
+% This ASCII file represents a sparse MxN matrix with L
+% nonzeros in the following Matrix Market format:
+%
+% +----------------------------------------------+
+% |%%MatrixMarket matrix coordinate real general | <--- header line
+% |%                                             | <--+
+% |% comments                                    |    |-- 0+ comment lines
+% |%                                             | <--+
+% |    M  N  L                                   | <--- rows, columns, entries
+% |    I1  J1  A(I1, J1)                         | <--+
+% |    I2  J2  A(I2, J2)                         |    |
+% |    I3  J3  A(I3, J3)                         |    |-- L lines
+% |        . . .                                 |    |
+% |    IL JL  A(IL, JL)                          | <--+
+% +----------------------------------------------+
+%
+% Indices are 1-based, i.e. A(1,1) is the first element.
+%
+%===============================================================================
+4 4 4
+1 1
+2 2
+3 3
+4 4

--- a/sprs/src/io.rs
+++ b/sprs/src/io.rs
@@ -826,6 +826,7 @@ mod test {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn read_pattern_matrix() {
         let path = "data/matrix_market/pattern.mm";
         let mat = read_matrix_market::<Pattern, usize, _>(path).unwrap();
@@ -856,6 +857,7 @@ mod test {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn read_non_pattern_mtx_to_pattern() {
         let path = "data/matrix_market/simple.mm";
         let mat = read_matrix_market::<Pattern, usize, _>(path).unwrap();

--- a/sprs/src/io.rs
+++ b/sprs/src/io.rs
@@ -857,7 +857,6 @@ mod test {
         let mat = read_matrix_market::<Pattern, usize, _>(path).unwrap();
         println!("trimat: {:?}", mat);
         let csc = mat.to_csc();
-        assert_eq!(csc.get(0, 0), Some(&Pattern {}));
         assert_eq!(csc.get(1, 1), Some(&Pattern {}));
         assert_eq!(csc.get(2, 2), Some(&Pattern {}));
         assert_eq!(csc.get(3, 3), Some(&Pattern {}));
@@ -879,5 +878,20 @@ mod test {
         write_matrix_market(&save_path, &csc).unwrap();
         let mat2 = read_matrix_market::<Pattern, usize, _>(&save_path).unwrap();
         assert_eq!(csc, mat2.to_csc());
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn read_csc_to_csr_trans() {
+        let path = "data/matrix_market/simple.mm";
+        let mat = read_matrix_market::<Pattern, usize, _>(path).unwrap();
+        println!("trimat: {:?}", mat);
+        let csc: CsMat<Pattern> = mat.to_csc();
+        let csr = csc.to_csr();
+        let csc_copy = csr.to_csc();
+        let csr_copy = csc_copy.to_csr();
+
+        assert_eq!(csc, csc_copy);
+        assert_eq!(csr, csr_copy);
     }
 }

--- a/sprs/src/num_kinds.rs
+++ b/sprs/src/num_kinds.rs
@@ -8,7 +8,7 @@ use std::{
     ops::{Add, Neg},
 };
 /// the type for Pattern data, it's special which contains no data
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Default)]
 pub struct Pattern;
 
 impl Add for Pattern {

--- a/sprs/src/num_kinds.rs
+++ b/sprs/src/num_kinds.rs
@@ -2,13 +2,106 @@
 //! or a complex.
 
 use num_complex::{Complex32, Complex64};
-use std::fmt;
+use num_traits::{Num, NumCast, One, ToPrimitive, Zero};
+use std::{
+    fmt,
+    ops::{Add, Div, Mul, Rem, Sub},
+};
+/// the type for Pattern data, it's special which contains no data
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct Pattern {}
+
+impl Add for Pattern {
+    type Output = Pattern;
+    fn add(self, _other: Pattern) -> Pattern {
+        Pattern {}
+    }
+}
+impl Zero for Pattern {
+    fn zero() -> Self {
+        Pattern {}
+    }
+    fn is_zero(&self) -> bool {
+        true
+    }
+
+    fn set_zero(&mut self) {
+        *self = Zero::zero();
+    }
+}
+impl Rem for Pattern {
+    type Output = Self;
+    fn rem(self, _rhs: Self) -> Self {
+        Pattern {}
+    }
+}
+impl Div for Pattern {
+    type Output = Self;
+    fn div(self, _rhs: Self) -> Self {
+        Pattern {}
+    }
+}
+impl Sub for Pattern {
+    type Output = Self;
+    fn sub(self, _rhs: Self) -> Self {
+        Pattern {}
+    }
+}
+impl Mul for Pattern {
+    type Output = Self;
+
+    fn mul(self, _rhs: Self) -> Self::Output {
+        Pattern {}
+    }
+}
+impl One for Pattern {
+    fn one() -> Self {
+        Pattern {}
+    }
+}
+impl Num for Pattern {
+    type FromStrRadixErr = ();
+
+    fn from_str_radix(
+        _str: &str,
+        _radix: u32,
+    ) -> Result<Self, Self::FromStrRadixErr> {
+        Err(())
+    }
+}
+
+impl std::ops::Neg for Pattern {
+    type Output = Pattern;
+
+    fn neg(self) -> Self::Output {
+        self
+    }
+}
+
+impl ToPrimitive for Pattern {
+    fn to_i64(&self) -> Option<i64> {
+        None
+    }
+    fn to_u64(&self) -> Option<u64> {
+        None
+    }
+    fn to_f64(&self) -> Option<f64> {
+        None
+    }
+}
+
+impl NumCast for Pattern {
+    fn from<T: num_traits::ToPrimitive>(_n: T) -> Option<Self> {
+        None
+    }
+}
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum NumKind {
     Integer,
     Float,
     Complex,
+    Pattern,
 }
 
 impl fmt::Display for NumKind {
@@ -17,6 +110,7 @@ impl fmt::Display for NumKind {
             Self::Integer => write!(f, "integer"),
             Self::Float => write!(f, "real"),
             Self::Complex => write!(f, "complex"),
+            Self::Pattern => write!(f, "pattern"),
         }
     }
 }
@@ -25,6 +119,11 @@ pub trait PrimitiveKind {
     /// Informs whether a generic primitive type contains an integer,
     /// a float or a complex
     fn num_kind() -> NumKind;
+}
+impl PrimitiveKind for Pattern {
+    fn num_kind() -> NumKind {
+        NumKind::Pattern
+    }
 }
 
 macro_rules! integer_prim_kind_impl {

--- a/sprs/src/num_kinds.rs
+++ b/sprs/src/num_kinds.rs
@@ -2,10 +2,10 @@
 //! or a complex.
 
 use num_complex::{Complex32, Complex64};
-use num_traits::{Num, NumCast, One, ToPrimitive, Zero};
+
 use std::{
     fmt,
-    ops::{Add, Div, Mul, Rem, Sub},
+    ops::{Add, Neg},
 };
 /// the type for Pattern data, it's special which contains no data
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
@@ -17,82 +17,10 @@ impl Add for Pattern {
         Pattern {}
     }
 }
-impl Zero for Pattern {
-    fn zero() -> Self {
-        Pattern {}
-    }
-    fn is_zero(&self) -> bool {
-        true
-    }
-
-    fn set_zero(&mut self) {
-        *self = Zero::zero();
-    }
-}
-impl Rem for Pattern {
-    type Output = Self;
-    fn rem(self, _rhs: Self) -> Self {
-        Pattern {}
-    }
-}
-impl Div for Pattern {
-    type Output = Self;
-    fn div(self, _rhs: Self) -> Self {
-        Pattern {}
-    }
-}
-impl Sub for Pattern {
-    type Output = Self;
-    fn sub(self, _rhs: Self) -> Self {
-        Pattern {}
-    }
-}
-impl Mul for Pattern {
-    type Output = Self;
-
-    fn mul(self, _rhs: Self) -> Self::Output {
-        Pattern {}
-    }
-}
-impl One for Pattern {
-    fn one() -> Self {
-        Pattern {}
-    }
-}
-impl Num for Pattern {
-    type FromStrRadixErr = ();
-
-    fn from_str_radix(
-        _str: &str,
-        _radix: u32,
-    ) -> Result<Self, Self::FromStrRadixErr> {
-        Err(())
-    }
-}
-
-impl std::ops::Neg for Pattern {
+impl Neg for Pattern {
     type Output = Pattern;
-
-    fn neg(self) -> Self::Output {
-        self
-    }
-}
-
-impl ToPrimitive for Pattern {
-    fn to_i64(&self) -> Option<i64> {
-        None
-    }
-    fn to_u64(&self) -> Option<u64> {
-        None
-    }
-    fn to_f64(&self) -> Option<f64> {
-        None
-    }
-}
-
-impl NumCast for Pattern {
-    fn from<T: num_traits::ToPrimitive>(_n: T) -> Option<Self> {
-        None
+    fn neg(self) -> Pattern {
+        Pattern {}
     }
 }
 

--- a/sprs/src/num_kinds.rs
+++ b/sprs/src/num_kinds.rs
@@ -9,7 +9,7 @@ use std::{
 };
 /// the type for Pattern data, it's special which contains no data
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub struct Pattern {}
+pub struct Pattern;
 
 impl Add for Pattern {
     type Output = Pattern;

--- a/sprs/src/num_matrixmarket.rs
+++ b/sprs/src/num_matrixmarket.rs
@@ -5,8 +5,16 @@ use std::fmt::Display;
 use std::str::SplitWhitespace;
 
 use crate::io::IoError::BadMatrixMarketFile;
+use crate::num_kinds::Pattern;
 
 pub struct Displayable<T>(T);
+
+impl<'a> Display for Displayable<&'a Pattern> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // write nothing for pattern
+        write!(f, "")
+    }
+}
 
 pub trait MatrixMarketDisplay
 where
@@ -75,6 +83,11 @@ complex_matrixmarket_display_impl!(f32);
 pub trait MatrixMarketRead: Sized {
     fn mm_read(r: &mut SplitWhitespace) -> Result<Self, crate::io::IoError>;
 }
+impl MatrixMarketRead for Pattern {
+    fn mm_read(_: &mut SplitWhitespace) -> Result<Self, crate::io::IoError> {
+        Ok(Pattern {})
+    }
+}
 
 macro_rules! matrixmarket_read_impl {
     (Complex<$t:ty>) => {
@@ -127,6 +140,11 @@ where
     Self: Sized,
 {
     fn mm_conj(&self) -> Option<Self>;
+}
+impl MatrixMarketConjugate for Pattern {
+    fn mm_conj(&self) -> Option<Self> {
+        None
+    }
 }
 
 macro_rules! matrixmarket_conjugate_impl {

--- a/sprs/src/sparse/triplet.rs
+++ b/sprs/src/sparse/triplet.rs
@@ -1,6 +1,6 @@
 use crate::indexing::SpIndex;
 use crate::sparse::prelude::*;
-use num_traits::Num;
+
 ///! Triplet format matrix
 ///!
 ///! Useful for building a matrix, but not for computations. Therefore this
@@ -11,7 +11,7 @@ use num_traits::Num;
 ///! the row indices, the column indices, and the values of the non-zero
 ///! entries. By convention, duplicate locations are summed up when converting
 ///! into `CsMat`.
-use std::ops::{Deref, DerefMut};
+use std::ops::{Add, Deref, DerefMut};
 use std::slice::Iter;
 
 /// Indexing type into a Triplet
@@ -259,7 +259,7 @@ where
     /// Create a CSC matrix from this triplet matrix
     pub fn to_csc<Iptr: SpIndex>(&self) -> CsMatI<N, I, Iptr>
     where
-        N: Clone + Num,
+        N: Clone + Add<Output = N>,
     {
         self.triplet_iter().into_csc()
     }
@@ -267,7 +267,7 @@ where
     /// Create a CSR matrix from this triplet matrix
     pub fn to_csr<Iptr: SpIndex>(&self) -> CsMatI<N, I, Iptr>
     where
-        N: Clone + Num,
+        N: Clone + Add<Output = N>,
     {
         self.triplet_iter().into_csr()
     }


### PR DESCRIPTION
the [pattern]( https://math.nist.gov/MatrixMarket/formats.html#MMformat) type is simply a zero-sized structure. update the io module to support:
1. read an MTX file with pattern type
2. read a normal non-pattern MTX file as a pattern-type MTX, ignore the data filed. #318 