### PR TITLE
Modifying the default implementation for MulAcc.

### DIFF
--- a/sprs/src/mul_acc.rs
+++ b/sprs/src/mul_acc.rs
@@ -4,7 +4,7 @@
 //! implementation that does not require cloning, which should prove useful
 //! when defining sparse matrices per blocks (eg BSR, BSC)
 
-use std::ops::{Mul, AddAssign};
+use std::ops::{AddAssign, Mul};
 
 /// Trait for types that have a multiply-accumulate operation, as required
 /// in dot products and matrix products.
@@ -23,7 +23,7 @@ pub trait MulAcc<A = Self, B = A> {
 impl<N, A, B> MulAcc<A, B> for N
 where
     for<'x> &'x A: Mul<&'x B, Output = N>,
-    N: AddAssign<N> 
+    N: AddAssign<N>,
 {
     fn mul_acc(&mut self, a: &A, b: &B) {
         self.add_assign(a * b);

--- a/sprs/src/mul_acc.rs
+++ b/sprs/src/mul_acc.rs
@@ -22,7 +22,7 @@ pub trait MulAcc<A = Self, B = A> {
 /// Default for types which supports `mul_add`
 impl<N, A, B> MulAcc<A, B> for N
 where
-    for<'x, 'y> &'x A: Mul<&'y B, Output = N>,
+    for<'x> &'x A: Mul<&'x B, Output = N>,
     N: AddAssign<N> 
 {
     fn mul_acc(&mut self, a: &A, b: &B) {

--- a/sprs/src/mul_acc.rs
+++ b/sprs/src/mul_acc.rs
@@ -4,6 +4,8 @@
 //! implementation that does not require cloning, which should prove useful
 //! when defining sparse matrices per blocks (eg BSR, BSC)
 
+use std::ops::{Mul, AddAssign};
+
 /// Trait for types that have a multiply-accumulate operation, as required
 /// in dot products and matrix products.
 ///
@@ -20,12 +22,11 @@ pub trait MulAcc<A = Self, B = A> {
 /// Default for types which supports `mul_add`
 impl<N, A, B> MulAcc<A, B> for N
 where
-    N: Copy,
-    B: Copy,
-    A: num_traits::MulAdd<B, N, Output = N> + Copy,
+    for<'x, 'y> &'x A: Mul<&'y B, Output = N>,
+    N: AddAssign<N> 
 {
     fn mul_acc(&mut self, a: &A, b: &B) {
-        *self = a.mul_add(*b, *self);
+        self.add_assign(a * b);
     }
 }
 

--- a/sprs/src/sparse/csmat.rs
+++ b/sprs/src/sparse/csmat.rs
@@ -2809,6 +2809,7 @@ mod test {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn diag_mut() {
         // | 1 0 0 3 1 |
         // | 0 2 0 0 0 |


### PR DESCRIPTION
Modified the default implementation of `MulAcc`, so that the default implementation applies to scalar types that does not necessary implement `Copy` and `num_traits::MulAdd`. In particular, this modification enables [`BigInt`](https://github.com/rust-num/num-bigint) and [`Rational`](https://github.com/rust-num/num-rational) types applicable. 

Follows discussion from #323. 