### PR TITLE
Fix link to heat.rs in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Matrix matrix multiplication, addition
   assert_eq!(a, b.to_csr());
 ```
 
-For a more complete example, be sure to check out the [heat diffusion](examples/heat.rs) example.
+For a more complete example, be sure to check out the [heat diffusion](sprs/examples/heat.rs) example.
 
 
 ## Documentation


### PR DESCRIPTION
I noticed that the link to `heat.rs` in `README.md` was broken, so I fixed it.