### PR TITLE
Add append_outer_iter

### DIFF
--- a/sprs/src/sparse/csmat.rs
+++ b/sprs/src/sparse/csmat.rs
@@ -563,6 +563,9 @@ impl<N, I: SpIndex, Iptr: SpIndex> CsMatI<N, I, Iptr> {
         N: Num,
         Iter: Iterator<Item = (usize, N)>,
     {
+        if let (_, Some(nnz)) = iter.size_hint() {
+            self.reserve_nnz(nnz)
+        }
         let mut nnz = self.nnz();
         let mut prev_inner_ind = None;
         for (inner_ind, val) in iter {

--- a/sprs/src/sparse/csmat.rs
+++ b/sprs/src/sparse/csmat.rs
@@ -556,7 +556,8 @@ impl<N, I: SpIndex, Iptr: SpIndex> CsMatI<N, I, Iptr> {
         self.append_outer_iter(data.iter().cloned().enumerate())
     }
 
-    /// Append an outer dim to an existing matrix, provided by an iterator
+    /// Append an outer dim to an existing matrix, increasing the size along the outer
+    /// dimension by one.
     pub fn append_outer_iter<Iter>(mut self, iter: Iter) -> Self
     where
         N: Num,

--- a/sprs/src/sparse/csmat.rs
+++ b/sprs/src/sparse/csmat.rs
@@ -722,7 +722,7 @@ impl<N, Iter: Iterator<Item = (usize, N)>> Iterator
 
         if let Some(prev_idx) = self.prev {
             assert!(
-                idx < prev_idx,
+                prev_idx < idx,
                 "index out of order. {} followed {}",
                 idx,
                 prev_idx


### PR DESCRIPTION
We use sprs for large sparse matrices with dims > 250,000,000. Currently the options to build a matrix requires realizing a `CsVecI` or a dense vector, which is inefficient.

Adding `append_outer_iter` helps with this without adding much code.
Makes e.g. filtering out a component from a large matrix much simpler and efficient.