### PR TITLE
Add more permutation functionality

### DIFF
--- a/sprs/src/lib.rs
+++ b/sprs/src/lib.rs
@@ -109,8 +109,8 @@ pub use crate::mul_acc::MulAcc;
 pub use crate::sparse::symmetric::is_symmetric;
 
 pub use crate::sparse::permutation::{
-    perm_is_valid, transform_mat_papt, PermOwned, PermOwnedI, PermView,
-    PermViewI, Permutation,
+    perm_is_valid, permute_cols, permute_rows, transform_mat_papt,
+    transform_mat_paq, PermOwned, PermOwnedI, PermView, PermViewI, Permutation,
 };
 
 pub use crate::sparse::CompressedStorage::{self, CSC, CSR};


### PR DESCRIPTION
* Add private functions `permute_inner` and `permute_outer` that separate the permutation of inner and outer dimensions as found in `transform_mat_papt`
* Add public functions `permute_rows` and `permute_cols` that select either `permute_inner` or `permute_outer` depending on storage
* Add public function `transform_mat_paq` that mirrors `transform_mat_papt` but allows different permutations for rows and cols and allows nonsquare matrices
* Use `transform_mat_paq` to test umfpack bindings' numeric factorization outputs
  * Incidentally macroize umfpack tests to reduce boilerplate overhead