### PR TITLE
DOC: Add instructions for enabling `dl_eigen` feature while building …

### DIFF
--- a/sprs-benches/README.md
+++ b/sprs-benches/README.md
@@ -10,3 +10,12 @@ and running the benchmarks as follows:
 ```
 cargo +nightly run --release --features nightly
 ```
+
+To enable the `dl_eigen` feature, run the following command
+
+```
+cargo build --features sprs-benches/dl_eigen
+```
+OR
+
+Install the C++ Eigen package globally [link](https://gitlab.com/libeigen/eigen/-/blob/master/INSTALL?ref_type=heads)


### PR DESCRIPTION
Added instructions to `sprs-benches/README.md` describing how to build the features with `dl_eigen` enabled.