### PR TITLE
chore: widen ndarray version

### DIFF
--- a/sprs-ldl/Cargo.toml
+++ b/sprs-ldl/Cargo.toml
@@ -18,4 +18,4 @@ sprs_suitesparse_ldl = { version = "0.8.0", path = "../suitesparse_bindings/sprs
 sprs_suitesparse_camd = { version = "0.3.0", path = "../suitesparse_bindings/sprs_suitesparse_camd", optional = true }
 
 [dev-dependencies]
-ndarray = ">=0.11.0,<0.16"
+ndarray = ">=0.15.0,<=0.16"

--- a/sprs/Cargo.toml
+++ b/sprs/Cargo.toml
@@ -21,7 +21,7 @@ multi_thread = ["dep:rayon", "dep:num_cpus"]
 
 [dependencies]
 num-traits = "0.2.0"
-ndarray = "0.15"
+ndarray = ">=0.15,<=0.16"
 alga = { version = "0.9.0", optional = true }
 num-complex = "0.4.0"
 serde = { version = "1.0.0", optional = true, features = ["derive"] }

--- a/sprs/benches/sparse_dense_products.rs
+++ b/sprs/benches/sparse_dense_products.rs
@@ -41,6 +41,7 @@ fn sparse_dense_vec_matprod_specialized(bench: &mut Bencher) {
     );
     let rows = a.rows();
     let cols = w.shape()[0];
+    #[allow(deprecated)]
     let w_reshape = w.view().into_shape((1, cols)).unwrap();
     let w_t = w_reshape.t();
     let mut res = Array2::<f64>::zeros((rows, 1).f());

--- a/sprs/examples/heat.rs
+++ b/sprs/examples/heat.rs
@@ -158,6 +158,7 @@ fn main() {
                 "Solved system in {} iterations with residual error {}",
                 iters, error
             );
+            #[allow(deprecated)]
             let grid = x.view().into_shape((rows, cols)).unwrap();
             for i in 0..rows {
                 for j in 0..cols {

--- a/sprs/src/sparse/csmat.rs
+++ b/sprs/src/sparse/csmat.rs
@@ -2123,9 +2123,11 @@ where
     fn mul(self, rhs: &'b ArrayBase<DS2, Ix1>) -> Array<N, Ix1> {
         let rows = self.rows();
         let cols = rhs.shape()[0];
+        #[allow(deprecated)]
         let rhs_reshape = rhs.view().into_shape((cols, 1)).unwrap();
         let mut res = Array::zeros(rows);
         {
+            #[allow(deprecated)]
             let res_reshape = res.view_mut().into_shape((rows, 1)).unwrap();
             match self.storage() {
                 CSR => {


### PR DESCRIPTION
It will build & tests pass with either 0.15 or 0.16.  We'd like to upgrade to ndarray 0.16.